### PR TITLE
salt is not a constant and should not be

### DIFF
--- a/RFC.md
+++ b/RFC.md
@@ -400,7 +400,7 @@ The private key is a 2048 RSA key.
 
 We have some defined constants to use for encryption and decryption of the private key:
 
-* salt: "$4$YmBjm3hk$Qb74D5IUYwghUmzsMqeNFx5z0/8$"
+* saltLength: 40 bytes
 * iterations: 1024
 * keyLength: 32 bytes (256 bit)
 * ivDelimiter: "fA=="


### PR DESCRIPTION
The description of the the RFC regarding the salt used by the private key encryption seems to be incorrect.
Implementations suggest that the salt is actually a generated value of 40 bytes, stored alongside the encrypted private key.